### PR TITLE
[For review & push] overwrite bootstrap variables and amended NavBar to latest color scheme

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -29,7 +29,7 @@
 }
 
 .navbar-rectangle {
-  background-color: #1D1F24;
+  // background-color: #1D1F24;
   margin-top: 20px;
   padding: 20px 25px;
   width: 100%;
@@ -48,14 +48,18 @@
 }
 
 .offcanvas-options {
-  color: #8a8a8e;
+  color: #787B8D;
 }
 
 .is-active {
-  color: white;
+  color: white !important;
 }
 
 .navbar-topics-link {
   text-decoration: none;
-  color: white;
+  color: #787B8D;
+
+  &:hover {
+    color: white;
+  }
 }

--- a/app/assets/stylesheets/config/_bootstrap_variables.scss
+++ b/app/assets/stylesheets/config/_bootstrap_variables.scss
@@ -12,11 +12,13 @@ $font-size-base:         1rem;
 
 // Colors
 $body-color: $gray;
-$primary:    $blue;
-$success:    $green;
+$primary:    $primary-purple;
+$success:    $alladin-purple;
 $info:       $yellow;
 $danger:     $red;
 $warning:    $orange;
+$light:      $light-purple;
+$secondary:  $mid-purple;
 
 // Buttons & inputs' radius
 $border-radius:    2px;

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -8,3 +8,7 @@ $orange: #E67E22;
 $green: #1EDD88;
 $gray: #0E0000;
 $light-gray: #F4F4F4;
+$primary-purple: #14172C;
+$light-purple: #C3C5D2;
+$mid-purple: #787B8D;
+$alladin-purple: #1999CE

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,13 @@
 // Import Google fonts
 @import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap');
+@import url('https://fonts.cdnfonts.com/css/helvetica-neue-55');
 
 // Define fonts for body and headers
-$body-font: "Work Sans", "Helvetica", "sans-serif";
-$headers-font: "Nunito", "Helvetica", "sans-serif";
+$body-font: "Roboto", "sans-serif";
+$headers-font: "Helvetica Neue", "sans-serif";
+
+
 
 // To use a font file (.woff) uncomment following lines
 // @font-face {

--- a/app/views/shared/_bottom_navbar.html.erb
+++ b/app/views/shared/_bottom_navbar.html.erb
@@ -11,30 +11,30 @@
 
 
   <nav class="navbar fixed-bottom">
-    <div class="navbar-rectangle">
+    <div class="navbar-rectangle bg-primary">
       <div class="container-fluid d-flex justify-content-between" data-controller="navbar-active" >
         <div>
-          <%= link_to cards_path, class: "nav-button d-flex flex-column align-items-center", data: { navbar_active_target: "home" } do %>
-            <i class="fa-solid fa-house-user nav-icon"></i>
+          <%= link_to cards_path, class: "nav-button d-flex flex-column align-items-center text-secondary", data: { navbar_active_target: "home" } do %>
+            <i class="fa-solid fa-house-user nav-icon "></i>
             Home
           <% end %>
         </div>
         <div>
-          <%= link_to new_card_path, class: "nav-button d-flex flex-column align-items-center", data: { navbar_active_target: "create" } do %>
-            <i class="fa-solid fa-circle-plus nav-icon"></i>
+          <%= link_to new_card_path, class: "nav-button d-flex flex-column align-items-center text-secondary", data: { navbar_active_target: "create" } do %>
+            <i class="fa-solid fa-circle-plus nav-icon "></i>
             Create
           <% end %>
         </div>
 
         <div>
-          <%= link_to favourites_path, class: "nav-button d-flex flex-column align-items-center", data: { navbar_active_target: "favourite" } do %>
-            <i class="fa-solid fa-heart nav-icon"></i>
+          <%= link_to favourites_path, class: "nav-button d-flex flex-column align-items-center text-secondary", data: { navbar_active_target: "favourite" } do %>
+            <i class="fa-solid fa-heart nav-icon "></i>
             Favourite
           <% end %>
         </div>
         <div>
-          <%= link_to edit_user_registration_path, class: "nav-button d-flex flex-column align-items-center", data: { navbar_active_target: "profile" } do %>
-            <i class="fa-regular fa-user nav-icon"></i>
+          <%= link_to edit_user_registration_path, class: "nav-button d-flex flex-column align-items-center text-secondary", data: { navbar_active_target: "profile" } do %>
+            <i class="fa-regular fa-user nav-icon "></i>
             Profile
           <% end %>
         </div>

--- a/app/views/shared/_side_navbar.html.erb
+++ b/app/views/shared/_side_navbar.html.erb
@@ -25,7 +25,7 @@
 
   <%# Section below is code pertaining to drawer/offcanvas %>
 
-  <div class="offcanvas offcanvas-start text-bg-dark rounded-top-right" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasDarkLabel" style="width: 200px;">
+  <div class="offcanvas offcanvas-start text-bg-primary rounded-top-right" tabindex="-1" id="offcanvasDark" aria-labelledby="offcanvasDarkLabel" style="width: 200px;">
     <div class="offcanvas-header">
       <h5 class="offcanvas-title mt-3" id="offcanvasDarkLabel">InfoGenie</h5>
       <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
@@ -38,25 +38,18 @@
           </div>
 
           <div class="mb-3 offcanvas-options">
-            Analytics
-          </div>
-
-          <div class="mb-3 offcanvas-options">
-            Reports
-          </div>
-
-          <div class="mb-3 offcanvas-options">
             Alerts
           </div>
 
           <div class="mb-3 offcanvas-options">
-            Help
+            FAQ
           </div>
           <% if user_signed_in? %>
-            <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
+            <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item navbar-topics-link" %>
           <% end %>
-          <div class="mt-auto offcanvas-options">
-            <i class="fa-solid fa-gear"></i> Profile Settings
+
+          <div class="mt-auto navbar-topics-link">
+            <i class="fa-solid fa-gear navbar-topics-link"></i> <%= link_to 'Profile Settings', edit_user_registration_path, class: "navbar-topics-link" %>
           </div>
 
         </div>


### PR DESCRIPTION
Things added:
Color and font variables overwritten in Bootstrap.
- body and header fonts defaults are updated, so when u use paragraphs and headers the font would b automatically applied.
- just call the color via the variable name. Success, light, primary, secondary these are the 4 variables with our color theme.

Navbars updated to latest color scheme.

